### PR TITLE
Restricted marker support

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.61.0-x86_64-unknown-linux-gnu
+          toolchain: 1.67.0-x86_64-unknown-linux-gnu
           default: true
           components: clippy, rustfmt
       - name: cargo format

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "marketpalace-subscription-contract"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marketpalace-subscription-contract"
-version = "2.0.0"
+version = "2.2.0"
 authors = ["Thomas Silva <tsilva@figure.com>"]
 edition = "2018"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,10 @@ pub mod contract;
 pub mod error;
 pub mod instantiate;
 pub mod migrate;
-pub mod mock;
 pub mod msg;
 pub mod raise_msg;
 pub mod state;
 pub mod version;
+
+#[cfg(test)]
+pub mod mock;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -4,7 +4,8 @@ use cosmwasm_std::Coin;
 use cosmwasm_std::CosmosMsg;
 use cosmwasm_std::Response;
 use cosmwasm_std::WasmMsg;
-use provwasm_std::ProvenanceMsg;
+use provwasm_mocks::{must_read_binary_file, ProvenanceMockQuerier};
+use provwasm_std::{Marker, MarkerMsgParams, ProvenanceMsg, ProvenanceMsgParams};
 use serde::de::DeserializeOwned;
 
 pub fn msg_at_index(res: &Response<ProvenanceMsg>, i: usize) -> &CosmosMsg<ProvenanceMsg> {
@@ -16,6 +17,27 @@ pub fn bank_msg(msg: &CosmosMsg<ProvenanceMsg>) -> &BankMsg {
         msg
     } else {
         panic!("not a cosmos bank message!")
+    }
+}
+
+pub fn marker_transfer_msg(msg: &CosmosMsg<ProvenanceMsg>) -> &MarkerMsgParams {
+    if let CosmosMsg::Custom(msg) = msg {
+        if let ProvenanceMsgParams::Marker(params) = &msg.params {
+            if let MarkerMsgParams::TransferMarkerCoins {
+                coin: _,
+                to: _,
+                from: _,
+            } = params
+            {
+                params
+            } else {
+                panic!("not a marker transfer message!")
+            }
+        } else {
+            panic!("not a marker message!")
+        }
+    } else {
+        panic!("not a cosmos custom message!")
     }
 }
 
@@ -48,4 +70,16 @@ pub fn execute_args<T: DeserializeOwned>(
     } else {
         panic!("not a wasm execute message")
     }
+}
+
+pub fn load_markers(querier: &mut ProvenanceMockQuerier) {
+    let get_marker = |name: &str| -> Marker {
+        let bin = must_read_binary_file(&format!("testdata/{}_marker.json", name));
+        from_binary(&bin).unwrap()
+    };
+
+    querier.with_markers(vec![
+        get_marker("capital"),
+        get_marker("restricted_capital"),
+    ]);
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -73,6 +73,30 @@ pub mod tests {
                 capital_per_share: 100,
             }
         }
+
+        pub fn test_capital_coin() -> State {
+            State {
+                admin: Addr::unchecked("admin"),
+                lp: Addr::unchecked("lp"),
+                raise: Addr::unchecked("raise_1"),
+                commitment_denom: String::from("raise_1.commitment"),
+                investment_denom: String::from("raise_1.investment"),
+                capital_denom: String::from("capital_coin"),
+                capital_per_share: 100,
+            }
+        }
+
+        pub fn test_restricted_capital_coin() -> State {
+            State {
+                admin: Addr::unchecked("admin"),
+                lp: Addr::unchecked("lp"),
+                raise: Addr::unchecked("raise_1"),
+                commitment_denom: String::from("raise_1.commitment"),
+                investment_denom: String::from("raise_1.investment"),
+                capital_denom: String::from("restricted_capital_coin"),
+                capital_per_share: 100,
+            }
+        }
     }
 
     #[test]

--- a/testdata/capital_marker.json
+++ b/testdata/capital_marker.json
@@ -1,0 +1,30 @@
+{
+    "address": "tp1v5st64kzeuddsqkderddprpkg5upce4xuwdhdl",
+    "coins": [
+      {
+        "denom": "capital_coin",
+        "amount": "420"
+      }
+    ],
+    "public_key": "",
+    "account_number": 10,
+    "sequence": 0,
+    "permissions": [
+      {
+        "permissions": [
+          "burn",
+          "delete",
+          "deposit",
+          "admin",
+          "mint",
+          "withdraw"
+        ],
+        "address": "tp1v5st64kzeuddsqkderddprpkg5upce4xuwdhdl"
+      }
+    ],
+    "status": "active",
+    "denom": "capital_coin",
+    "total_supply": "420",
+    "marker_type": "coin",
+    "supply_fixed": false
+  }

--- a/testdata/restricted_capital_marker.json
+++ b/testdata/restricted_capital_marker.json
@@ -1,0 +1,30 @@
+{
+    "address": "tp19dmdhtyd2x2uzsecdsjdrjjn06pawnj3eas5wk",
+    "coins": [
+      {
+        "denom": "restricted_capital_coin",
+        "amount": "420"
+      }
+    ],
+    "public_key": "",
+    "account_number": 10,
+    "sequence": 0,
+    "permissions": [
+      {
+        "permissions": [
+          "burn",
+          "delete",
+          "deposit",
+          "admin",
+          "mint",
+          "withdraw"
+        ],
+        "address": "tp19dmdhtyd2x2uzsecdsjdrjjn06pawnj3eas5wk"
+      }
+    ],
+    "status": "active",
+    "denom": "restricted_capital_coin",
+    "total_supply": "420",
+    "marker_type": "restricted",
+    "supply_fixed": false
+  }


### PR DESCRIPTION
Add support for restricted markers, update contract to 2.2.0, and update github build to use Rust 1.67.