### PR TITLE
Restricted marker support

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.61.0-x86_64-unknown-linux-gnu
+          toolchain: 1.67.0-x86_64-unknown-linux-gnu
           default: true
           components: clippy, rustfmt
       - name: cargo format

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "marketpalace-subscription-contract"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marketpalace-subscription-contract"
-version = "2.0.0"
+version = "2.2.0"
 authors = ["Thomas Silva <tsilva@figure.com>"]
 edition = "2018"
 

--- a/schema/instantiate_msg.json
+++ b/schema/instantiate_msg.json
@@ -38,6 +38,12 @@
     },
     "lp": {
       "$ref": "#/definitions/Addr"
+    },
+    "required_capital_attribute": {
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "definitions": {

--- a/schema/instantiate_msg.json
+++ b/schema/instantiate_msg.json
@@ -25,16 +25,6 @@
     "commitment_denom": {
       "type": "string"
     },
-    "fiat_deposit_addr": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Addr"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "initial_commitment": {
       "type": [
         "integer",

--- a/schema/instantiate_msg.json
+++ b/schema/instantiate_msg.json
@@ -25,6 +25,16 @@
     "commitment_denom": {
       "type": "string"
     },
+    "fiat_deposit_addr": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Addr"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "initial_commitment": {
       "type": [
         "integer",

--- a/schema/state.json
+++ b/schema/state.json
@@ -26,16 +26,6 @@
     "commitment_denom": {
       "type": "string"
     },
-    "fiat_deposit_addr": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Addr"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "investment_denom": {
       "type": "string"
     },

--- a/schema/state.json
+++ b/schema/state.json
@@ -26,6 +26,16 @@
     "commitment_denom": {
       "type": "string"
     },
+    "fiat_deposit_addr": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Addr"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "investment_denom": {
       "type": "string"
     },

--- a/schema/state.json
+++ b/schema/state.json
@@ -34,6 +34,12 @@
     },
     "raise": {
       "$ref": "#/definitions/Addr"
+    },
+    "required_capital_attribute": {
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "definitions": {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -127,19 +127,7 @@ pub fn execute(
                         ));
                         response
                     }
-                    Some(required_capital_attribute) => {
-                        if !query_attributes(deps, &state.raise)
-                            .any(|attr| attr.name == required_capital_attribute)
-                        {
-                            return contract_error(
-                                format!(
-                                    "{} does not have required attribute of {}",
-                                    &state.raise, &required_capital_attribute
-                                )
-                                .as_str(),
-                            );
-                        }
-
+                    Some(_required_capital_attribute) => {
                         let marker_transfer = transfer_marker_coins(
                             total_capital.unsigned_abs().into(),
                             &state.capital_denom,

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -116,9 +116,9 @@ pub fn execute(
                 ));
             }
 
-            let mut response = Response::new();
+            let response = Response::new();
             let total_capital: i64 = exchanges.iter().filter_map(|e| e.capital).sum();
-            if total_capital < 0 {
+            let response = if total_capital < 0 {
                 match state.fiat_deposit_addr {
                     Some(fiat_deposit_addr) => {
                         let fiat_deposit_transfer = wasm_execute(
@@ -129,16 +129,19 @@ pub fn execute(
                             },
                             vec![],
                         )?;
-                        response = response.add_message(fiat_deposit_transfer)
+                        response.add_message(fiat_deposit_transfer)
                     }
                     None => {
                         funds.push(coin(
                             total_capital.unsigned_abs().into(),
                             state.capital_denom.clone(),
                         ));
+                        response
                     }
-                };
-            }
+                }
+            } else {
+                response
+            };
 
             funds.sort_by_key(|coin| coin.denom.clone());
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -116,9 +116,9 @@ pub fn execute(
                 ));
             }
 
-            let response = Response::new();
+            let mut response = Response::new();
             let total_capital: i64 = exchanges.iter().filter_map(|e| e.capital).sum();
-            let response = if total_capital < 0 {
+            if total_capital < 0 {
                 match state.fiat_deposit_addr {
                     Some(fiat_deposit_addr) => {
                         let fiat_deposit_transfer = wasm_execute(
@@ -129,19 +129,16 @@ pub fn execute(
                             },
                             vec![],
                         )?;
-                        response.add_message(fiat_deposit_transfer)
+                        response = response.add_message(fiat_deposit_transfer)
                     }
                     None => {
                         funds.push(coin(
                             total_capital.unsigned_abs().into(),
                             state.capital_denom.clone(),
                         ));
-                        response
                     }
-                }
-            } else {
-                response
-            };
+                };
+            }
 
             funds.sort_by_key(|coin| coin.denom.clone());
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -5,11 +5,10 @@ use cosmwasm_std::{
     coins, entry_point, to_binary, BankMsg, Binary, Deps, DepsMut, Env, MessageInfo, Response,
     StdResult,
 };
-use provwasm_std::ProvenanceMsg;
 use provwasm_std::ProvenanceQuery;
+use provwasm_std::{transfer_marker_coins, MarkerType, ProvenanceMsg, ProvenanceQuerier};
 
 use crate::error::ContractError;
-use crate::fiat_deposit_msg::FiatDepositExecuteMsg;
 use crate::msg::{AssetExchange, HandleMsg, QueryMsg};
 use crate::state::{
     asset_exchange_authorization_storage, asset_exchange_authorization_storage_read, state_storage,
@@ -117,26 +116,23 @@ pub fn execute(
             }
 
             let mut response = Response::new();
+            let capital_marker =
+                ProvenanceQuerier::new(&deps.querier).get_marker_by_denom(&state.capital_denom)?;
             let total_capital: i64 = exchanges.iter().filter_map(|e| e.capital).sum();
             if total_capital < 0 {
-                match state.fiat_deposit_addr {
-                    Some(fiat_deposit_addr) => {
-                        let fiat_deposit_transfer = wasm_execute(
-                            fiat_deposit_addr.into_string(),
-                            &FiatDepositExecuteMsg::Transfer {
-                                amount: total_capital.unsigned_abs().into(),
-                                recipient: state.raise.clone().into(),
-                            },
-                            vec![],
-                        )?;
-                        response = response.add_message(fiat_deposit_transfer)
-                    }
-                    None => {
-                        funds.push(coin(
-                            total_capital.unsigned_abs().into(),
-                            state.capital_denom.clone(),
-                        ));
-                    }
+                if capital_marker.marker_type == MarkerType::Coin {
+                    funds.push(coin(
+                        total_capital.unsigned_abs().into(),
+                        state.capital_denom.clone(),
+                    ));
+                } else {
+                    let marker_transfer = transfer_marker_coins(
+                        total_capital.unsigned_abs().into(),
+                        &state.capital_denom,
+                        state.raise.clone(),
+                        _env.contract.address,
+                    )?;
+                    response = response.add_message(marker_transfer);
                 };
             }
 
@@ -159,25 +155,22 @@ pub fn execute(
                 return contract_error("only the lp can withdraw");
             }
 
-            let response = match state.fiat_deposit_addr {
-                Some(fiat_deposit_addr) => {
-                    let fiat_deposit_transfer = wasm_execute(
-                        fiat_deposit_addr.into_string(),
-                        &FiatDepositExecuteMsg::Transfer {
-                            amount: amount.into(),
-                            recipient: to.into_string(),
-                        },
-                        vec![],
-                    )?;
-                    Response::new().add_message(fiat_deposit_transfer)
-                }
-                None => {
-                    let send_capital = BankMsg::Send {
-                        to_address: to.to_string(),
-                        amount: coins(amount.into(), state.capital_denom),
-                    };
-                    Response::new().add_message(send_capital)
-                }
+            let capital_marker =
+                ProvenanceQuerier::new(&deps.querier).get_marker_by_denom(&state.capital_denom)?;
+            let response = if capital_marker.marker_type == MarkerType::Coin {
+                let send_capital = BankMsg::Send {
+                    to_address: to.to_string(),
+                    amount: coins(amount.into(), state.capital_denom),
+                };
+                Response::new().add_message(send_capital)
+            } else {
+                let marker_transfer = transfer_marker_coins(
+                    amount.into(),
+                    &state.capital_denom,
+                    to,
+                    _env.contract.address,
+                )?;
+                Response::new().add_message(marker_transfer)
             };
             Ok(response)
         }
@@ -223,18 +216,19 @@ pub fn query(deps: Deps<ProvenanceQuery>, _env: Env, msg: QueryMsg) -> StdResult
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mock::msg_at_index;
     use crate::mock::send_msg;
     use crate::mock::{execute_args, load_markers};
+    use crate::mock::{marker_transfer_msg, msg_at_index};
     use crate::msg::AssetExchange;
     use crate::state::asset_exchange_authorization_storage_read;
     use crate::state::State;
-    use cosmwasm_std::testing::MockApi;
     use cosmwasm_std::testing::MockStorage;
     use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::testing::{MockApi, MOCK_CONTRACT_ADDR};
+    use cosmwasm_std::Addr;
     use cosmwasm_std::OwnedDeps;
-    use cosmwasm_std::{Addr, Uint128};
     use provwasm_mocks::{mock_dependencies, ProvenanceMockQuerier};
+    use provwasm_std::MarkerMsgParams;
 
     pub fn default_deps(
         update_state: Option<fn(&mut State)>,
@@ -264,12 +258,12 @@ mod tests {
         deps
     }
 
-    pub fn restricted_fiat_deposit_coin_deps(
+    pub fn restricted_capital_coin_deps(
         update_state: Option<fn(&mut State)>,
     ) -> OwnedDeps<MockStorage, MockApi, ProvenanceMockQuerier, ProvenanceQuery> {
         let mut deps = mock_dependencies(&[]);
 
-        let mut state = State::test_fiat_deposit_capital_coin();
+        let mut state = State::test_restricted_capital_coin();
         if let Some(update) = update_state {
             update(&mut state);
         }
@@ -527,8 +521,8 @@ mod tests {
     }
 
     #[test]
-    fn complete_asset_exchange_fiat_deposit_send_only() {
-        let mut deps = restricted_fiat_deposit_coin_deps(None);
+    fn complete_asset_exchange_restricted_marker_send_only() {
+        let mut deps = restricted_capital_coin_deps(None);
         load_markers(&mut deps.querier);
         let exchange = AssetExchange {
             investment: Some(-1_000),
@@ -550,18 +544,6 @@ mod tests {
         )
         .unwrap();
 
-        // verify capital was transferred
-        let (_recipient, msg, fiat_deposit_funds) =
-            execute_args::<FiatDepositExecuteMsg>(msg_at_index(&res, 0));
-        assert_eq!(
-            FiatDepositExecuteMsg::Transfer {
-                amount: Uint128::from(2_000 as u128),
-                recipient: "raise_1".into(),
-            },
-            msg
-        );
-        assert_eq!(0, fiat_deposit_funds.len());
-
         // verify exec message sent
         assert_eq!(2, res.messages.len());
         let (recipient, msg, funds) = execute_args::<RaiseExecuteMsg>(msg_at_index(&res, 1));
@@ -575,7 +557,18 @@ mod tests {
             msg
         );
 
+        // verify funds sent
+        assert_eq!(
+            &MarkerMsgParams::TransferMarkerCoins {
+                coin: coin(2_000, "restricted_capital_coin"),
+                to: Addr::unchecked("raise_1"),
+                from: Addr::unchecked(MOCK_CONTRACT_ADDR),
+            },
+            marker_transfer_msg(msg_at_index(&res, 0)),
+        );
         assert_eq!(2, funds.len());
+        // let capital = funds.get(0).unwrap();
+        // assert_eq!(2_000, capital.amount.u128());
         let commitment = funds.get(0).unwrap();
         assert_eq!(2_000, commitment.amount.u128());
         let investment = funds.get(1).unwrap();
@@ -700,8 +693,8 @@ mod tests {
     }
 
     #[test]
-    fn withdraw_fiat_deposit_marker() {
-        let mut deps = restricted_fiat_deposit_coin_deps(None);
+    fn withdraw_restricted_marker() {
+        let mut deps = restricted_capital_coin_deps(None);
         load_markers(&mut deps.querier);
         let res = execute(
             deps.as_mut(),
@@ -716,17 +709,14 @@ mod tests {
 
         // verify send message sent
         assert_eq!(1, res.messages.len());
-        // verify capital was transferred
-        let (_recipient, msg, fiat_deposit_funds) =
-            execute_args::<FiatDepositExecuteMsg>(msg_at_index(&res, 0));
         assert_eq!(
-            FiatDepositExecuteMsg::Transfer {
-                amount: Uint128::from(10_000 as u128),
-                recipient: "lp_side_account".into(),
+            &MarkerMsgParams::TransferMarkerCoins {
+                coin: coin(10_000, "restricted_capital_coin"),
+                to: Addr::unchecked("lp_side_account"),
+                from: Addr::unchecked(MOCK_CONTRACT_ADDR),
             },
-            msg
+            marker_transfer_msg(msg_at_index(&res, 0)),
         );
-        assert_eq!(0, fiat_deposit_funds.len());
     }
 
     #[test]

--- a/src/fiat_deposit_msg.rs
+++ b/src/fiat_deposit_msg.rs
@@ -1,0 +1,8 @@
+use cosmwasm_std::Uint128;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum FiatDepositExecuteMsg {
+    Transfer { amount: Uint128, recipient: String },
+}

--- a/src/fiat_deposit_msg.rs
+++ b/src/fiat_deposit_msg.rs
@@ -1,8 +1,0 @@
-use cosmwasm_std::Uint128;
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum FiatDepositExecuteMsg {
-    Transfer { amount: Uint128, recipient: String },
-}

--- a/src/instantiate.rs
+++ b/src/instantiate.rs
@@ -34,7 +34,6 @@ pub fn instantiate(
         investment_denom: msg.investment_denom,
         capital_denom: msg.capital_denom,
         capital_per_share: msg.capital_per_share,
-        fiat_deposit_addr: msg.fiat_deposit_addr,
     };
 
     state_storage(deps.storage).save(&state)?;
@@ -86,7 +85,6 @@ mod tests {
                 capital_denom: String::from("stable_coin"),
                 capital_per_share: 100,
                 initial_commitment: Some(100),
-                fiat_deposit_addr: None,
             },
         )
         .unwrap();

--- a/src/instantiate.rs
+++ b/src/instantiate.rs
@@ -34,6 +34,7 @@ pub fn instantiate(
         investment_denom: msg.investment_denom,
         capital_denom: msg.capital_denom,
         capital_per_share: msg.capital_per_share,
+        fiat_deposit_addr: msg.fiat_deposit_addr,
     };
 
     state_storage(deps.storage).save(&state)?;
@@ -85,6 +86,7 @@ mod tests {
                 capital_denom: String::from("stable_coin"),
                 capital_per_share: 100,
                 initial_commitment: Some(100),
+                fiat_deposit_addr: None,
             },
         )
         .unwrap();

--- a/src/instantiate.rs
+++ b/src/instantiate.rs
@@ -34,6 +34,7 @@ pub fn instantiate(
         investment_denom: msg.investment_denom,
         capital_denom: msg.capital_denom,
         capital_per_share: msg.capital_per_share,
+        required_capital_attribute: msg.required_capital_attribute,
     };
 
     state_storage(deps.storage).save(&state)?;
@@ -85,6 +86,7 @@ mod tests {
                 capital_denom: String::from("stable_coin"),
                 capital_per_share: 100,
                 initial_commitment: Some(100),
+                required_capital_attribute: None,
             },
         )
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,10 @@ pub mod contract;
 pub mod error;
 pub mod instantiate;
 pub mod migrate;
-pub mod mock;
 pub mod msg;
 pub mod raise_msg;
 pub mod state;
 pub mod version;
+
+#[cfg(test)]
+pub mod mock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod contract;
 pub mod error;
-pub mod fiat_deposit_msg;
 pub mod instantiate;
 pub mod migrate;
 pub mod msg;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 pub mod error;
+pub mod fiat_deposit_msg;
 pub mod instantiate;
 pub mod migrate;
 pub mod msg;

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -42,7 +42,6 @@ pub fn migrate(
         investment_denom: format!("{}.investment", old_state.raise),
         capital_denom: old_state.capital_denom,
         capital_per_share: old_state.capital_per_share,
-        fiat_deposit_addr: None,
     };
 
     state_storage(deps.storage).save(&new_state)?;
@@ -228,7 +227,6 @@ mod tests {
                 investment_denom: String::from("raise_1.investment"),
                 capital_denom: String::from("stable_coin"),
                 capital_per_share: 100,
-                fiat_deposit_addr: None,
             },
             singleton_read(&deps.storage, CONFIG_KEY).load().unwrap()
         );

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -42,6 +42,7 @@ pub fn migrate(
         investment_denom: format!("{}.investment", old_state.raise),
         capital_denom: old_state.capital_denom,
         capital_per_share: old_state.capital_per_share,
+        required_capital_attribute: None,
     };
 
     state_storage(deps.storage).save(&new_state)?;
@@ -227,6 +228,7 @@ mod tests {
                 investment_denom: String::from("raise_1.investment"),
                 capital_denom: String::from("stable_coin"),
                 capital_per_share: 100,
+                required_capital_attribute: None,
             },
             singleton_read(&deps.storage, CONFIG_KEY).load().unwrap()
         );

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -42,6 +42,7 @@ pub fn migrate(
         investment_denom: format!("{}.investment", old_state.raise),
         capital_denom: old_state.capital_denom,
         capital_per_share: old_state.capital_per_share,
+        fiat_deposit_addr: None,
     };
 
     state_storage(deps.storage).save(&new_state)?;
@@ -227,6 +228,7 @@ mod tests {
                 investment_denom: String::from("raise_1.investment"),
                 capital_denom: String::from("stable_coin"),
                 capital_per_share: 100,
+                fiat_deposit_addr: None,
             },
             singleton_read(&deps.storage, CONFIG_KEY).load().unwrap()
         );

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::CosmosMsg;
 use cosmwasm_std::Response;
 use cosmwasm_std::WasmMsg;
 use provwasm_mocks::{must_read_binary_file, ProvenanceMockQuerier};
-use provwasm_std::{Marker, ProvenanceMsg};
+use provwasm_std::{Marker, MarkerMsgParams, ProvenanceMsg, ProvenanceMsgParams};
 use serde::de::DeserializeOwned;
 
 pub fn msg_at_index(res: &Response<ProvenanceMsg>, i: usize) -> &CosmosMsg<ProvenanceMsg> {
@@ -17,6 +17,27 @@ pub fn bank_msg(msg: &CosmosMsg<ProvenanceMsg>) -> &BankMsg {
         msg
     } else {
         panic!("not a cosmos bank message!")
+    }
+}
+
+pub fn marker_transfer_msg(msg: &CosmosMsg<ProvenanceMsg>) -> &MarkerMsgParams {
+    if let CosmosMsg::Custom(msg) = msg {
+        if let ProvenanceMsgParams::Marker(params) = &msg.params {
+            if let MarkerMsgParams::TransferMarkerCoins {
+                coin: _,
+                to: _,
+                from: _,
+            } = params
+            {
+                params
+            } else {
+                panic!("not a marker transfer message!")
+            }
+        } else {
+            panic!("not a marker message!")
+        }
+    } else {
+        panic!("not a cosmos custom message!")
     }
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::CosmosMsg;
 use cosmwasm_std::Response;
 use cosmwasm_std::WasmMsg;
 use provwasm_mocks::{must_read_binary_file, ProvenanceMockQuerier};
-use provwasm_std::{Marker, MarkerMsgParams, ProvenanceMsg, ProvenanceMsgParams};
+use provwasm_std::{Marker, ProvenanceMsg};
 use serde::de::DeserializeOwned;
 
 pub fn msg_at_index(res: &Response<ProvenanceMsg>, i: usize) -> &CosmosMsg<ProvenanceMsg> {
@@ -17,27 +17,6 @@ pub fn bank_msg(msg: &CosmosMsg<ProvenanceMsg>) -> &BankMsg {
         msg
     } else {
         panic!("not a cosmos bank message!")
-    }
-}
-
-pub fn marker_transfer_msg(msg: &CosmosMsg<ProvenanceMsg>) -> &MarkerMsgParams {
-    if let CosmosMsg::Custom(msg) = msg {
-        if let ProvenanceMsgParams::Marker(params) = &msg.params {
-            if let MarkerMsgParams::TransferMarkerCoins {
-                coin: _,
-                to: _,
-                from: _,
-            } = params
-            {
-                params
-            } else {
-                panic!("not a marker transfer message!")
-            }
-        } else {
-            panic!("not a marker message!")
-        }
-    } else {
-        panic!("not a cosmos custom message!")
     }
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -4,7 +4,8 @@ use cosmwasm_std::Coin;
 use cosmwasm_std::CosmosMsg;
 use cosmwasm_std::Response;
 use cosmwasm_std::WasmMsg;
-use provwasm_std::ProvenanceMsg;
+use provwasm_mocks::{must_read_binary_file, ProvenanceMockQuerier};
+use provwasm_std::{Marker, MarkerMsgParams, ProvenanceMsg, ProvenanceMsgParams};
 use serde::de::DeserializeOwned;
 
 pub fn msg_at_index(res: &Response<ProvenanceMsg>, i: usize) -> &CosmosMsg<ProvenanceMsg> {
@@ -16,6 +17,27 @@ pub fn bank_msg(msg: &CosmosMsg<ProvenanceMsg>) -> &BankMsg {
         msg
     } else {
         panic!("not a cosmos bank message!")
+    }
+}
+
+pub fn marker_transfer_msg(msg: &CosmosMsg<ProvenanceMsg>) -> &MarkerMsgParams {
+    if let CosmosMsg::Custom(msg) = msg {
+        if let ProvenanceMsgParams::Marker(params) = &msg.params {
+            if let MarkerMsgParams::TransferMarkerCoins {
+                coin: _,
+                to: _,
+                from: _,
+            } = params
+            {
+                params
+            } else {
+                panic!("not a marker transfer message!")
+            }
+        } else {
+            panic!("not a marker message!")
+        }
+    } else {
+        panic!("not a cosmos custom message!")
     }
 }
 
@@ -48,4 +70,16 @@ pub fn execute_args<T: DeserializeOwned>(
     } else {
         panic!("not a wasm execute message")
     }
+}
+
+pub fn load_markers(querier: &mut ProvenanceMockQuerier) {
+    let get_marker = |name: &str| -> Marker {
+        let bin = must_read_binary_file(&format!("testdata/{}_marker.json", name));
+        from_binary(&bin).unwrap()
+    };
+
+    querier.with_markers(vec![
+        get_marker("capital"),
+        get_marker("restricted_capital"),
+    ]);
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -12,7 +12,6 @@ pub struct InstantiateMsg {
     pub capital_denom: String,
     pub capital_per_share: u64,
     pub initial_commitment: Option<u64>,
-    pub fiat_deposit_addr: Option<Addr>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -12,6 +12,7 @@ pub struct InstantiateMsg {
     pub capital_denom: String,
     pub capital_per_share: u64,
     pub initial_commitment: Option<u64>,
+    pub fiat_deposit_addr: Option<Addr>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -12,6 +12,7 @@ pub struct InstantiateMsg {
     pub capital_denom: String,
     pub capital_per_share: u64,
     pub initial_commitment: Option<u64>,
+    pub required_capital_attribute: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,7 +18,6 @@ pub struct State {
     pub investment_denom: String,
     pub capital_denom: String,
     pub capital_per_share: u64,
-    pub fiat_deposit_addr: Option<Addr>,
 }
 
 impl State {
@@ -72,7 +71,6 @@ pub mod tests {
                 investment_denom: String::from("raise_1.investment"),
                 capital_denom: String::from("stable_coin"),
                 capital_per_share: 100,
-                fiat_deposit_addr: None,
             }
         }
 
@@ -85,7 +83,6 @@ pub mod tests {
                 investment_denom: String::from("raise_1.investment"),
                 capital_denom: String::from("capital_coin"),
                 capital_per_share: 100,
-                fiat_deposit_addr: None,
             }
         }
 
@@ -98,20 +95,6 @@ pub mod tests {
                 investment_denom: String::from("raise_1.investment"),
                 capital_denom: String::from("restricted_capital_coin"),
                 capital_per_share: 100,
-                fiat_deposit_addr: None,
-            }
-        }
-
-        pub fn test_fiat_deposit_capital_coin() -> State {
-            State {
-                admin: Addr::unchecked("admin"),
-                lp: Addr::unchecked("lp"),
-                raise: Addr::unchecked("raise_1"),
-                commitment_denom: String::from("raise_1.commitment"),
-                investment_denom: String::from("raise_1.investment"),
-                capital_denom: String::from("restricted_capital_coin"),
-                capital_per_share: 100,
-                fiat_deposit_addr: Some(Addr::unchecked("fiatdeposit")),
             }
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,6 +18,7 @@ pub struct State {
     pub investment_denom: String,
     pub capital_denom: String,
     pub capital_per_share: u64,
+    pub fiat_deposit_addr: Option<Addr>,
 }
 
 impl State {
@@ -71,6 +72,7 @@ pub mod tests {
                 investment_denom: String::from("raise_1.investment"),
                 capital_denom: String::from("stable_coin"),
                 capital_per_share: 100,
+                fiat_deposit_addr: None,
             }
         }
 
@@ -83,6 +85,7 @@ pub mod tests {
                 investment_denom: String::from("raise_1.investment"),
                 capital_denom: String::from("capital_coin"),
                 capital_per_share: 100,
+                fiat_deposit_addr: None,
             }
         }
 
@@ -95,6 +98,20 @@ pub mod tests {
                 investment_denom: String::from("raise_1.investment"),
                 capital_denom: String::from("restricted_capital_coin"),
                 capital_per_share: 100,
+                fiat_deposit_addr: None,
+            }
+        }
+
+        pub fn test_fiat_deposit_capital_coin() -> State {
+            State {
+                admin: Addr::unchecked("admin"),
+                lp: Addr::unchecked("lp"),
+                raise: Addr::unchecked("raise_1"),
+                commitment_denom: String::from("raise_1.commitment"),
+                investment_denom: String::from("raise_1.investment"),
+                capital_denom: String::from("restricted_capital_coin"),
+                capital_per_share: 100,
+                fiat_deposit_addr: Some(Addr::unchecked("fiatdeposit")),
             }
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,6 +18,7 @@ pub struct State {
     pub investment_denom: String,
     pub capital_denom: String,
     pub capital_per_share: u64,
+    pub required_capital_attribute: Option<String>,
 }
 
 impl State {
@@ -71,6 +72,7 @@ pub mod tests {
                 investment_denom: String::from("raise_1.investment"),
                 capital_denom: String::from("stable_coin"),
                 capital_per_share: 100,
+                required_capital_attribute: None,
             }
         }
 
@@ -83,6 +85,7 @@ pub mod tests {
                 investment_denom: String::from("raise_1.investment"),
                 capital_denom: String::from("capital_coin"),
                 capital_per_share: 100,
+                required_capital_attribute: None,
             }
         }
 
@@ -95,6 +98,7 @@ pub mod tests {
                 investment_denom: String::from("raise_1.investment"),
                 capital_denom: String::from("restricted_capital_coin"),
                 capital_per_share: 100,
+                required_capital_attribute: Some(String::from("capital.test")),
             }
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -73,6 +73,30 @@ pub mod tests {
                 capital_per_share: 100,
             }
         }
+
+        pub fn test_capital_coin() -> State {
+            State {
+                admin: Addr::unchecked("admin"),
+                lp: Addr::unchecked("lp"),
+                raise: Addr::unchecked("raise_1"),
+                commitment_denom: String::from("raise_1.commitment"),
+                investment_denom: String::from("raise_1.investment"),
+                capital_denom: String::from("capital_coin"),
+                capital_per_share: 100,
+            }
+        }
+
+        pub fn test_restricted_capital_coin() -> State {
+            State {
+                admin: Addr::unchecked("admin"),
+                lp: Addr::unchecked("lp"),
+                raise: Addr::unchecked("raise_1"),
+                commitment_denom: String::from("raise_1.commitment"),
+                investment_denom: String::from("raise_1.investment"),
+                capital_denom: String::from("restricted_capital_coin"),
+                capital_per_share: 100,
+            }
+        }
     }
 
     #[test]

--- a/testdata/capital_marker.json
+++ b/testdata/capital_marker.json
@@ -1,0 +1,30 @@
+{
+    "address": "tp1v5st64kzeuddsqkderddprpkg5upce4xuwdhdl",
+    "coins": [
+      {
+        "denom": "capital_coin",
+        "amount": "420"
+      }
+    ],
+    "public_key": "",
+    "account_number": 10,
+    "sequence": 0,
+    "permissions": [
+      {
+        "permissions": [
+          "burn",
+          "delete",
+          "deposit",
+          "admin",
+          "mint",
+          "withdraw"
+        ],
+        "address": "tp1v5st64kzeuddsqkderddprpkg5upce4xuwdhdl"
+      }
+    ],
+    "status": "active",
+    "denom": "capital_coin",
+    "total_supply": "420",
+    "marker_type": "coin",
+    "supply_fixed": false
+  }

--- a/testdata/restricted_capital_marker.json
+++ b/testdata/restricted_capital_marker.json
@@ -1,0 +1,30 @@
+{
+    "address": "tp19dmdhtyd2x2uzsecdsjdrjjn06pawnj3eas5wk",
+    "coins": [
+      {
+        "denom": "restricted_capital_coin",
+        "amount": "420"
+      }
+    ],
+    "public_key": "",
+    "account_number": 10,
+    "sequence": 0,
+    "permissions": [
+      {
+        "permissions": [
+          "burn",
+          "delete",
+          "deposit",
+          "admin",
+          "mint",
+          "withdraw"
+        ],
+        "address": "tp19dmdhtyd2x2uzsecdsjdrjjn06pawnj3eas5wk"
+      }
+    ],
+    "status": "active",
+    "denom": "restricted_capital_coin",
+    "total_supply": "420",
+    "marker_type": "restricted",
+    "supply_fixed": false
+  }


### PR DESCRIPTION
Restricted marker support needed to be put in for utilizing Bank in a Box coin.