### PR TITLE
Add support to update capital denomination as admin

### DIFF
--- a/schema/handle_msg.json
+++ b/schema/handle_msg.json
@@ -164,6 +164,26 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "update_capital_denomination"
+      ],
+      "properties": {
+        "update_capital_denomination": {
+          "type": "object",
+          "required": [
+            "capital_denomination"
+          ],
+          "properties": {
+            "capital_denomination": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -192,6 +192,21 @@ pub fn execute(
             };
             Ok(response)
         }
+        HandleMsg::UpdateCapitalDenomination {
+            capital_denomination,
+        } => {
+            let mut state = state_storage_read(deps.storage).load()?;
+
+            if info.sender != state.admin {
+                return contract_error("only the admin can update capital denomination");
+            }
+
+            state.capital_denom = capital_denomination;
+
+            state_storage(deps.storage).save(&state)?;
+
+            Ok(Response::new())
+        }
     }
 }
 
@@ -766,5 +781,24 @@ mod tests {
             },
         );
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn update_capital_denomination() {
+        let mut deps = default_deps(None);
+
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("admin", &vec![]),
+            HandleMsg::UpdateCapitalDenomination {
+                capital_denomination: String::from("new_denom"),
+            },
+        )
+        .unwrap();
+
+        // verify that denom has been updated
+        let state = state_storage_read(&deps.storage).load().unwrap();
+        assert_eq!(String::from("new_denom"), state.capital_denom);
     }
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -44,6 +44,9 @@ pub enum HandleMsg {
         to: Addr,
         amount: u64,
     },
+    UpdateCapitalDenomination {
+        capital_denomination: String,
+    },
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, JsonSchema)]


### PR DESCRIPTION
Capital denomination needs to be updated by the admin account for all contracts.