### PR TITLE
Tsilva/sc 256087/multi like capital denom

### DIFF
--- a/schema/handle_msg.json
+++ b/schema/handle_msg.json
@@ -149,6 +149,7 @@
           "type": "object",
           "required": [
             "amount",
+            "capital_denom",
             "to"
           ],
           "properties": {
@@ -156,6 +157,9 @@
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
+            },
+            "capital_denom": {
+              "type": "string"
             },
             "to": {
               "$ref": "#/definitions/Addr"
@@ -180,6 +184,12 @@
             "null"
           ],
           "format": "int64"
+        },
+        "cap_d": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "com": {
           "type": [

--- a/schema/handle_msg.json
+++ b/schema/handle_msg.json
@@ -149,7 +149,6 @@
           "type": "object",
           "required": [
             "amount",
-            "capital_denom",
             "to"
           ],
           "properties": {
@@ -159,7 +158,10 @@
               "minimum": 0.0
             },
             "capital_denom": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "to": {
               "$ref": "#/definitions/Addr"

--- a/schema/instantiate_msg.json
+++ b/schema/instantiate_msg.json
@@ -4,18 +4,15 @@
   "type": "object",
   "required": [
     "admin",
-    "capital_denom",
     "capital_per_share",
     "commitment_denom",
     "investment_denom",
+    "like_capital_denoms",
     "lp"
   ],
   "properties": {
     "admin": {
       "$ref": "#/definitions/Addr"
-    },
-    "capital_denom": {
-      "type": "string"
     },
     "capital_per_share": {
       "type": "integer",
@@ -35,6 +32,12 @@
     },
     "investment_denom": {
       "type": "string"
+    },
+    "like_capital_denoms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "lp": {
       "$ref": "#/definitions/Addr"

--- a/schema/state.json
+++ b/schema/state.json
@@ -4,19 +4,16 @@
   "type": "object",
   "required": [
     "admin",
-    "capital_denom",
     "capital_per_share",
     "commitment_denom",
     "investment_denom",
+    "like_capital_denoms",
     "lp",
     "raise"
   ],
   "properties": {
     "admin": {
       "$ref": "#/definitions/Addr"
-    },
-    "capital_denom": {
-      "type": "string"
     },
     "capital_per_share": {
       "type": "integer",
@@ -28,6 +25,12 @@
     },
     "investment_denom": {
       "type": "string"
+    },
+    "like_capital_denoms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "lp": {
       "$ref": "#/definitions/Addr"

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -120,7 +120,7 @@ pub fn execute(
 
             let response = Response::new();
 
-            let total_capital_per_denom: HashMap<String, i64> = exchanges.iter().fold(
+            let total_capital_per_denom: HashMap<String, i64> = exchanges.iter().try_fold(
                 HashMap::new(),
                 |mut acc,
                  AssetExchange {
@@ -128,14 +128,21 @@ pub fn execute(
                      capital,
                      ..
                  }| {
-                    if let Some(value) = capital {
-                        *acc.entry(capital_denom.clone().unwrap()).or_insert(0) += value;
-                        acc
-                    } else {
-                        acc
+                    if let Some(capital_value) = capital {
+                        let denom = if let Some(denom_value) = capital_denom {
+                            denom_value.clone()
+                        } else if state.like_capital_denoms.len() == 1 {
+                            state.like_capital_denoms.first().unwrap().clone()
+                        } else {
+                            return Err(StdError::generic_err("no capital denom")) 
+                        };
+
+                        *acc.entry(denom).or_insert(0) += capital_value;
                     }
+
+                    Ok(acc)
                 },
-            );
+            )?;
 
             let response = total_capital_per_denom.into_iter().try_fold(
                 response,

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -134,7 +134,7 @@ pub fn execute(
                         } else if state.like_capital_denoms.len() == 1 {
                             state.like_capital_denoms.first().unwrap().clone()
                         } else {
-                            return Err(StdError::generic_err("no capital denom")) 
+                            return Err(StdError::generic_err("no capital denom"));
                         };
 
                         *acc.entry(denom).or_insert(0) += capital_value;
@@ -147,11 +147,11 @@ pub fn execute(
             let response = total_capital_per_denom.into_iter().try_fold(
                 response,
                 |response, (capital_denom, capital_sum)| -> Result<_, StdError> {
-                    if capital_sum < 0 {
+                    Ok(if capital_sum < 0 {
                         match &state.required_capital_attribute {
                             None => {
                                 funds.push(coin(capital_sum.unsigned_abs().into(), capital_denom));
-                                Ok(response)
+                                response
                             }
                             Some(_required_capital_attribute) => {
                                 let marker_transfer = transfer_marker_coins(
@@ -160,12 +160,12 @@ pub fn execute(
                                     state.raise.clone(),
                                     env.contract.address.clone(),
                                 )?;
-                                Ok(response.add_message(marker_transfer))
+                                response.add_message(marker_transfer)
                             }
                         }
                     } else {
-                        Ok(response)
-                    }
+                        response
+                    })
                 },
             )?;
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -51,6 +51,20 @@ pub fn execute(
                 return contract_error("only the lp can authorize asset exchanges");
             }
 
+            if state.like_capital_denoms.len() > 1 {
+                for exchange in &exchanges {
+                    if exchange.capital.is_some() {
+                        if let Some(denom_value) = &exchange.capital_denom {
+                            if !state.like_capital_denoms.contains(denom_value) {
+                                return contract_error("unsupported capital denom");
+                            }
+                        } else {
+                            return contract_error("specified capital denom required");
+                        }
+                    }
+                }
+            }
+
             let mut authorizations = asset_exchange_authorization_storage(deps.storage)
                 .may_load()?
                 .unwrap_or_default();

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -854,4 +854,42 @@ mod tests {
         );
         assert!(res.is_err());
     }
+
+    #[test]
+    fn withdraw_required_cap_denom_not_specified() {
+        let mut deps = default_deps(Some(|state| {
+            state.like_capital_denoms = vec![String::from("a"), String::from("b")];
+        }));
+
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("lp", &vec![]),
+            HandleMsg::IssueWithdrawal {
+                to: Addr::unchecked("lp_side_account"),
+                amount: 10_000,
+                capital_denom: None,
+            },
+        );
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn withdraw_unsupported_cap_denom() {
+        let mut deps = default_deps(Some(|state| {
+            state.like_capital_denoms = vec![String::from("a")];
+        }));
+
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("lp", &vec![]),
+            HandleMsg::IssueWithdrawal {
+                to: Addr::unchecked("lp_side_account"),
+                amount: 10_000,
+                capital_denom: Some(String::from("b")),
+            },
+        );
+        assert!(res.is_err());
+    }
 }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -143,10 +143,7 @@ pub fn execute(
                     if capital_sum < 0 {
                         match &state.required_capital_attribute {
                             None => {
-                                funds.push(coin(
-                                    capital_sum.unsigned_abs().into(),
-                                    capital_denom.clone(),
-                                ));
+                                funds.push(coin(capital_sum.unsigned_abs().into(), capital_denom));
                                 Ok(response)
                             }
                             Some(_required_capital_attribute) => {
@@ -613,7 +610,7 @@ mod tests {
         let exchange = AssetExchange {
             investment: Some(-1_000),
             commitment_in_shares: Some(-1_000),
-            capital_denom: Some(String::from("stable_coin")),
+            capital_denom: Some(String::from("restricted_capital_coin")),
             capital: Some(-1_000),
             date: None,
         };
@@ -768,7 +765,7 @@ mod tests {
             mock_env(),
             mock_info("lp", &vec![]),
             HandleMsg::IssueWithdrawal {
-                capital_denom: String::from("stable_coin"),
+                capital_denom: String::from("capital_coin"),
                 to: Addr::unchecked("lp_side_account"),
                 amount: 10_000,
             },
@@ -793,7 +790,7 @@ mod tests {
             mock_env(),
             mock_info("lp", &vec![]),
             HandleMsg::IssueWithdrawal {
-                capital_denom: String::from("stable_coin"),
+                capital_denom: String::from("restricted_capital_coin"),
                 to: Addr::unchecked("lp_side_account"),
                 amount: 10_000,
             },

--- a/src/instantiate.rs
+++ b/src/instantiate.rs
@@ -32,7 +32,7 @@ pub fn instantiate(
         lp: msg.lp.clone(),
         commitment_denom: msg.commitment_denom,
         investment_denom: msg.investment_denom,
-        capital_denom: msg.capital_denom,
+        like_capital_denoms: msg.like_capital_denoms,
         capital_per_share: msg.capital_per_share,
         required_capital_attribute: msg.required_capital_attribute,
     };
@@ -45,6 +45,7 @@ pub fn instantiate(
                 exchanges: vec![AssetExchange {
                     investment: None,
                     commitment_in_shares: Some(commitment.try_into()?),
+                    capital_denom: None,
                     capital: None,
                     date: None,
                 }],
@@ -83,7 +84,7 @@ mod tests {
                 lp: Addr::unchecked("lp"),
                 commitment_denom: String::from("raise_1.commitment"),
                 investment_denom: String::from("raise_1.investment"),
-                capital_denom: String::from("stable_coin"),
+                like_capital_denoms: vec![String::from("stable_coin")],
                 capital_per_share: 100,
                 initial_commitment: Some(100),
                 required_capital_attribute: None,

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -29,17 +29,13 @@ pub fn migrate(
 
     let old_state: StateV2_0_0 = singleton_read(deps.storage, CONFIG_KEY).load()?;
 
-    let capital_denom = match migrate_msg.capital_denom {
-        None => old_state.capital_denom,
-        Some(capital_denom) => capital_denom,
-    };
     let new_state = State {
         admin: old_state.admin,
         lp: old_state.lp,
         raise: old_state.raise.clone(),
         commitment_denom: old_state.commitment_denom,
         investment_denom: old_state.investment_denom,
-        capital_denom,
+        like_capital_denoms: migrate_msg.like_capital_denoms,
         capital_per_share: old_state.capital_per_share,
         required_capital_attribute: migrate_msg.required_capital_attribute,
     };
@@ -58,6 +54,18 @@ pub struct StateV2_0_0 {
     pub investment_denom: String,
     pub capital_denom: String,
     pub capital_per_share: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct StateV2_2_0 {
+    pub admin: Addr,
+    pub lp: Addr,
+    pub raise: Addr,
+    pub commitment_denom: String,
+    pub investment_denom: String,
+    pub capital_denom: String,
+    pub capital_per_share: u64,
+    pub required_capital_attribute: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -181,7 +189,7 @@ mod tests {
             deps.as_mut(),
             mock_env(),
             MigrateMsg {
-                capital_denom: None,
+                like_capital_denoms: vec![String::from("stable_coin")],
                 required_capital_attribute: None,
             },
         )
@@ -194,7 +202,7 @@ mod tests {
                 raise: Addr::unchecked("raise_1"),
                 commitment_denom: String::from("commitment"),
                 investment_denom: String::from("investment"),
-                capital_denom: String::from("stable_coin"),
+                like_capital_denoms: vec![String::from("stable_coin")],
                 capital_per_share: 100,
                 required_capital_attribute: None,
             },
@@ -218,7 +226,7 @@ mod tests {
             .unwrap();
 
         let migration_msg = MigrateMsg {
-            capital_denom: Some(String::from("new_denom")),
+            like_capital_denoms: vec![String::from("new_denom")],
             required_capital_attribute: Some(String::from("attr")),
         };
         migrate(deps.as_mut(), mock_env(), migration_msg).unwrap();
@@ -230,7 +238,7 @@ mod tests {
                 raise: Addr::unchecked("raise_1"),
                 commitment_denom: String::from("commitment"),
                 investment_denom: String::from("investment"),
-                capital_denom: String::from("new_denom"),
+                like_capital_denoms: vec![String::from("new_denom")],
                 capital_per_share: 100,
                 required_capital_attribute: Some(String::from("attr")),
             },

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -9,7 +9,7 @@ pub struct InstantiateMsg {
     pub lp: Addr,
     pub commitment_denom: String,
     pub investment_denom: String,
-    pub capital_denom: String,
+    pub like_capital_denoms: Vec<String>,
     pub capital_per_share: u64,
     pub initial_commitment: Option<u64>,
     pub required_capital_attribute: Option<String>,
@@ -18,7 +18,7 @@ pub struct InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct MigrateMsg {
-    pub capital_denom: Option<String>,
+    pub like_capital_denoms: Vec<String>,
     pub required_capital_attribute: Option<String>,
 }
 
@@ -44,6 +44,7 @@ pub enum HandleMsg {
         memo: Option<String>,
     },
     IssueWithdrawal {
+        capital_denom: String,
         to: Addr,
         amount: u64,
     },
@@ -59,6 +60,10 @@ pub struct AssetExchange {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub commitment_in_shares: Option<i64>,
+    #[serde(rename = "cap_d")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capital_denom: Option<String>,
     #[serde(rename = "cap")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -61,8 +61,8 @@ pub struct AssetExchange {
     #[serde(default)]
     pub commitment_in_shares: Option<i64>,
     #[serde(rename = "cap_d")]
-    #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub capital_denom: Option<String>,
     #[serde(rename = "cap")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -44,9 +44,9 @@ pub enum HandleMsg {
         memo: Option<String>,
     },
     IssueWithdrawal {
-        capital_denom: String,
         to: Addr,
         amount: u64,
+        capital_denom: Option<String>,
     },
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -16,7 +16,7 @@ pub struct State {
     pub raise: Addr,
     pub commitment_denom: String,
     pub investment_denom: String,
-    pub capital_denom: String,
+    pub like_capital_denoms: Vec<String>,
     pub capital_per_share: u64,
     pub required_capital_attribute: Option<String>,
 }
@@ -70,7 +70,7 @@ pub mod tests {
                 raise: Addr::unchecked("raise_1"),
                 commitment_denom: String::from("raise_1.commitment"),
                 investment_denom: String::from("raise_1.investment"),
-                capital_denom: String::from("stable_coin"),
+                like_capital_denoms: vec![String::from("stable_coin")],
                 capital_per_share: 100,
                 required_capital_attribute: None,
             }
@@ -83,7 +83,7 @@ pub mod tests {
                 raise: Addr::unchecked("raise_1"),
                 commitment_denom: String::from("raise_1.commitment"),
                 investment_denom: String::from("raise_1.investment"),
-                capital_denom: String::from("capital_coin"),
+                like_capital_denoms: vec![String::from("capital_coin")],
                 capital_per_share: 100,
                 required_capital_attribute: None,
             }
@@ -96,7 +96,7 @@ pub mod tests {
                 raise: Addr::unchecked("raise_1"),
                 commitment_denom: String::from("raise_1.commitment"),
                 investment_denom: String::from("raise_1.investment"),
-                capital_denom: String::from("restricted_capital_coin"),
+                like_capital_denoms: vec![String::from("restricted_capital_coin")],
                 capital_per_share: 100,
                 required_capital_attribute: Some(String::from("capital.test")),
             }


### PR DESCRIPTION
- 1 cap denom -> mult like cap denoms
- 1 required attribute -> cap denom specified required attr
- backwards compatible asset exchange
- instantiate / migrate message parameter change
- checks for required cap denoms in various scenarios